### PR TITLE
Improved German Inserter Translations

### DIFF
--- a/locale/de/boblogistics.cfg
+++ b/locale/de/boblogistics.cfg
@@ -83,27 +83,27 @@ logistic-chest-storage-2=Lagerkiste MK2
 logistic-chest-requester-2=Anforderungskiste MK2
 
 
-long-handed-burner-inserter=Langer befeuerter Greifarm
+long-handed-burner-inserter=Befeuerter langer Greifarm
 
-fast-near-inserter=Schneller nah nehmender und legender Greifarm
-fast-far-inserter=Schneller weit nehmender und legender Greifarm
+fast-near-inserter=Schneller Greifarm (nahe Bandseite)
+fast-far-inserter=Schneller langer Greifarm (nahe Bandseite)
 fast-long-inserter=Schneller langer Greifarm
 
-filter-near-inserter=Filternder nah nehmender und legender Greifarm
-filter-short-far-inserter=Weit nehmender und legender filternder kurzer Standard Greifarm
-filter-short-long-inserter=Filternder kleiner langer Greifarm
-filter-long-near-inserter=Filternder nah nehmender und legender langer Greifarm
-filter-long-short-inserter=Filternder langer kleiner Greifarm
-filter-far-inserter=Filternder weit nehmender und legender Greifarm
+filter-near-inserter=Filternder Greifarm (nahe Bandseite)
+filter-short-far-inserter=Filtender Kurz->Lang Greifarm (nahe Bandseite)
+filter-short-long-inserter=Filternder Kurz->Lang Greifarm
+filter-long-near-inserter=Filternder Lang->Kurz Greifarm (nahe Bandseite)
+filter-long-short-inserter=Filternder Lang->Kurz Greifarm
+filter-far-inserter=Filternder langer Greifarm (nahe Bandseite)
 filter-long-inserter=Filternder langer Greifarm
 
-purple-near-inserter=Express nah nehmender und legender Greifarm
+purple-near-inserter=Express Greifarm (nahe Bandseite)
 purple-inserter=Express Greifarm
-purple-short-far-inserter=Express weit nehmender und legender kurzer Standard Greifarm
-purple-short-long-inserter=Express kleiner langer Standard Greifarm
-purple-long-near-inserter=Express nah nehmender und legender langer Greifarm
-purple-long-short-inserter=Express langer kleiner standard Greifarm
-purple-far-inserter=Express schneller Greifarm
+purple-short-far-inserter=Express Kurz->Lang Greifarm (nahe Bandseite)
+purple-short-long-inserter=Express Kurz->Lang Greifarm
+purple-long-near-inserter=Express Lang->Kurz Greifarm (nahe Bandseite)
+purple-long-short-inserter=Express Lang->Kurz Greifarm
+purple-far-inserter=Express langer Greifarm (nahe Bandseite)
 purple-long-inserter=Express langer Greifarm
 
 


### PR DESCRIPTION
The german inserter translations were very confusing, sometimes even completely wrong. I updated all of them with an easy to understand standard naming that at the same time follows the rules of the base-game (e.g. when an inserter puts items on the near side of a belt it is marked as "(nahe Bandseite)", however when it puts intems on the far side, there is no extra naming, because this is the standard behavior).
