### PR TITLE
fix for missing inserters names in russian locale

### DIFF
--- a/locale/ru/boblogistics.cfg
+++ b/locale/ru/boblogistics.cfg
@@ -236,9 +236,9 @@ express-long-short-inserter=Экспресс длинный-нормальный
 express-far-inserter=Экспресс удлинённый (2-1.5) манипулятор
 express-long-inserter=Экспресс длинный (2-2) манипулятор
 
-express-filter-inserter=
-express-stack-inserter=
-express-stack-filter-inserter=
+express-filter-inserter=Экспресс фильтрующий манипулятор
+express-stack-inserter=Экспресс пакетный манипулятор
+express-stack-filter-inserter=Экспресс пакетный фильтрующий
 
 
 green-transport-belt=Ускоренный конвейер


### PR DESCRIPTION
Empty names led to a lack of an item in the localization.